### PR TITLE
feat(cubejs,cubestore): add imagePullSecrets support

### DIFF
--- a/charts/cubejs/Chart.yaml
+++ b/charts/cubejs/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cubejs
 description: A Helm chart for Cubejs
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.28.32"
 keywords:
   - cubejs

--- a/charts/cubejs/templates/master/deployment.yaml
+++ b/charts/cubejs/templates/master/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         app.kubernetes.io/component: master
         {{- include "cubejs.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if .Values.master.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.master.nodeSelector | nindent 8 }}

--- a/charts/cubejs/templates/workers/deployment.yaml
+++ b/charts/cubejs/templates/workers/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         app.kubernetes.io/component: workers
         {{- include "cubejs.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if .Values.workers.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.workers.nodeSelector | nindent 8 }}

--- a/charts/cubejs/values.yaml
+++ b/charts/cubejs/values.yaml
@@ -14,6 +14,11 @@ commonLabels: {}
 ##
 commonAnnotations: {}
 
+## Optionally specify an array of imagePullSecrets
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+##
+imagePullSecrets: []
+
 image:
   ## Docker image repository
   ##

--- a/charts/cubestore/Chart.yaml
+++ b/charts/cubestore/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: cubestore
 description: A Helm chart for Cubestore
 type: application
-version: 0.1.8
+version: 0.1.9
 appVersion: "0.35.37-non-avx"
 keywords:
   - cubejs

--- a/charts/cubestore/templates/router/statefulset.yaml
+++ b/charts/cubestore/templates/router/statefulset.yaml
@@ -23,6 +23,10 @@ spec:
         app.kubernetes.io/component: router
         {{- include "cubestore.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       {{- if .Values.router.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.router.nodeSelector | nindent 8 }}

--- a/charts/cubestore/templates/workers/statefulset.yaml
+++ b/charts/cubestore/templates/workers/statefulset.yaml
@@ -25,6 +25,10 @@ spec:
         app.kubernetes.io/component: workers
         {{- include "cubestore.selectorLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.imagePullSecrets | nindent 8 }}
+      {{- end }}
       containers:
         - name: cubestore
           image: "{{ .Values.image.repository }}:v{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/cubestore/values.yaml
+++ b/charts/cubestore/values.yaml
@@ -14,6 +14,11 @@ commonLabels: {}
 ##
 commonAnnotations: {}
 
+## Optionally specify an array of imagePullSecrets
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+##
+imagePullSecrets: []
+
 image:
   ## Docker image repository
   ##


### PR DESCRIPTION
## Summary
- Adds `imagePullSecrets` support to all pod specs in cubejs and cubestore charts
- Defaults to `[]` (no-op) for backwards compatibility — existing deployments are unaffected
- Bumps cubestore 0.1.8 → 0.1.9, cubejs 0.1.4 → 0.1.5

## Context
The `crm-platform-infra` Terraform module passes `imagePullSecrets` to these charts via Helm `set` blocks, but the charts never templated them into pod specs. Unauthenticated Docker Hub pulls are rate-limited to 100/6h, causing `ImagePullBackOff` across cube pods.

## Changed templates
| Chart | Template | Change |
|---|---|---|
| cubestore | router/statefulset.yaml | Added `imagePullSecrets` block |
| cubestore | workers/statefulset.yaml | Added `imagePullSecrets` block |
| cubejs | master/deployment.yaml | Added `imagePullSecrets` block |
| cubejs | workers/deployment.yaml | Added `imagePullSecrets` block |

## Verification
- `helm template` with `--set imagePullSecrets[0].name=test` renders the secret in all pod specs
- `helm template` without the value renders no `imagePullSecrets` block (backwards compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)