### PR TITLE
ci: pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
@@ -20,11 +20,11 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
         with:
           version: v2.16.8
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.0
+        uses: helm/chart-releaser-action@a3454e46a6f5ac4811069a381e646961dda2e1bf # v1.4.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## What
Pins all third-party (and in-org composite) GitHub Action `uses:` references to a full-length 40-character commit SHA, with the original tag preserved in a trailing comment that Dependabot reads for updates.

## Why
Org-wide supply-chain hardening: the enterprise "require actions pinned to a full-length commit SHA" policy is enforcing, so any workflow with tag-pinned refs will fail CI. Mutable tags can also be repointed to a malicious commit by an attacker who compromises an action's repo (see the recent [Megalodon campaign](https://safedep.io/megalodon-mass-github-repo-backdooring-ci-workflows/) — 5k+ repos backdoored in a 6-hour window).

## Behaviour change
None. Each action runs at the same commit as the tag it was already on.
Generated by `pinact`.