### PR TITLE
feat(ci): publish a token-servable classic Helm repo to gh-pages

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -7,7 +7,8 @@ name: Release Charts
 # a read-only token, e.g.:
 #   helm repo add fasttrack \
 #     https://raw.githubusercontent.com/fasttrack-solutions/helm-charts/gh-pages/ \
-#     --username "$TOKEN" --password "$TOKEN"
+#     --username x-access-token --password "$TOKEN"
+# (GitHub ignores the basic-auth username; only the token authenticates.)
 # The chart URLs in index.yaml are relative filenames, so Helm resolves them
 # against the same raw base (same host => basic-auth credentials are reused).
 

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,5 +1,16 @@
 name: Release Charts
 
+# Publishes a self-contained classic Helm repo (index.yaml + *.tgz) to the
+# `gh-pages` branch tree. Because this repo is PRIVATE, GitHub Pages does not
+# serve it and chart-releaser's Releases-based layout can't be fetched with
+# HTTP basic auth. Consumers instead fetch over raw.githubusercontent.com with
+# a read-only token, e.g.:
+#   helm repo add fasttrack \
+#     https://raw.githubusercontent.com/fasttrack-solutions/helm-charts/gh-pages/ \
+#     --username "$TOKEN" --password "$TOKEN"
+# The chart URLs in index.yaml are relative filenames, so Helm resolves them
+# against the same raw base (same host => basic-auth credentials are reused).
+
 on:
   push:
     branches:
@@ -8,6 +19,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -22,9 +35,39 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab # v1.1
         with:
-          version: v2.16.8
+          version: v3.14.4
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@a3454e46a6f5ac4811069a381e646961dda2e1bf # v1.4.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Package charts and build index
+        run: |
+          set -euo pipefail
+          OUT="$(mktemp -d)"
+          for chart in charts/*/; do
+            [ -f "${chart}Chart.yaml" ] || continue
+            # Resolve local (file://) sub-chart dependencies before packaging.
+            helm dependency build "$chart" || helm dependency update "$chart" || true
+            helm package "$chart" -d "$OUT"
+          done
+          # Relative (bare-filename) URLs so the index is portable across the
+          # raw base URL used by consumers.
+          helm repo index "$OUT"
+          echo "OUT=$OUT" >> "$GITHUB_ENV"
+
+      - name: Publish to gh-pages
+        run: |
+          set -euo pipefail
+          git fetch origin gh-pages || true
+          if git show-ref --verify --quiet refs/remotes/origin/gh-pages; then
+            git worktree add gh-pages-wt origin/gh-pages
+          else
+            git worktree add --orphan -b gh-pages gh-pages-wt
+          fi
+          cp "$OUT"/*.tgz gh-pages-wt/
+          cp "$OUT"/index.yaml gh-pages-wt/index.yaml
+          cd gh-pages-wt
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No chart changes to publish."
+          else
+            git commit -m "Publish charts ($GITHUB_SHA)"
+            git push origin HEAD:gh-pages
+          fi


### PR DESCRIPTION
## Context
This repo was made **private** after a secret leak. That broke consumers (e.g. `crm-platform-infra`'s ambassador/cubejs/cubestore `helm_release`s) because:
1. **GitHub Pages is not served for private repos** — the old `github.io` base is dead.
2. **chart-releaser stores the `.tgz` on GitHub Releases** — private release assets need API-style auth, which Helm can't attach when following the `releases/download/...` URL from `index.yaml`.

## What this PR does
Replaces the `chart-releaser` step with a self-contained publish that keeps the repo private but makes it fetchable with a token:
- `helm package` every chart under `charts/*` (resolving local `file://` sub-chart deps for `cube-stack`).
- `helm repo index` with **relative (bare-filename) URLs**.
- Commit `index.yaml` + `*.tgz` into the **`gh-pages` branch tree**.

Consumers fetch over `raw.githubusercontent.com` (which honors HTTP basic auth for private repos) with a read-only token:
```
helm repo add fasttrack \
  https://raw.githubusercontent.com/fasttrack-solutions/helm-charts/gh-pages/ \
  --username "$TOKEN" --password "$TOKEN"
```
Relative chart URLs resolve against the same raw base (same host ⇒ basic-auth creds reused).

## Companion PRs (merge order)
1. **This PR first** — merge, let it publish to `gh-pages`, then verify:
   `curl -sf -u "<token>:" https://raw.githubusercontent.com/fasttrack-solutions/helm-charts/gh-pages/index.yaml`
2. Then `one-click-deployment-api` (injects `helm_repo_token`) and `crm-platform-infra` (switches consumers to the raw URL).

## Notes
- Requires a read-only token (fine-grained PAT, Contents:read on this repo) provisioned for the deployer. A single org-wide token is sufficient.
- Kept the existing SHA-pinned actions; only bumped Helm to v3.14.4 (packages the `apiVersion: v1` ambassador chart fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)